### PR TITLE
Fix footer only present in home

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,14 +1,14 @@
 import Navigation from "./Navigation";
+import Footer from "./Footer";
 
 const Layout = (props) => {
-    return (
-        <div>
-            <Navigation />
-            <main>
-                {props.children}
-            </main>
-        </div>
-    );
+  return (
+    <div>
+      <Navigation />
+      <main>{props.children}</main>
+      <Footer />
+    </div>
+  );
 };
 
 export default Layout;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -9,7 +9,6 @@ const Home = () => {
       <Landing />
       <TableDisplay />
       <Chart />
-      <Footer />
     </>
   );
 };


### PR DESCRIPTION
- Removed the Footer from the Home route and added it to the Layout component to it will be displayed in all the pages automatically.
- Because some of the pages are still not filled with contents, the footer appears in the middle, but it will be fixed as soon as new content is added.